### PR TITLE
Turn off the entity-id fetcher and start using frontend ids everywhere

### DIFF
--- a/src-cljs/frontend/components/app.cljs
+++ b/src-cljs/frontend/components/app.cljs
@@ -38,8 +38,7 @@
             right-click-learned? (get-in app state/right-click-learned-path)]
         (html [:div.inner {:on-click (when (overlay-visible? app)
                                        #(cast! :overlay-closed))
-                           :class (when (and (empty? (:frontend-id-state app))
-                                             (:use-frontend-ids app))
+                           :class (when (empty? (:frontend-id-state app))
                                     "loading")}
                [:style "#om-app:active{cursor:auto}"]
                (om/build canvas/canvas app)

--- a/src-cljs/frontend/controllers/api.cljs
+++ b/src-cljs/frontend/controllers/api.cljs
@@ -66,10 +66,6 @@
   (put! (get-in current-state [:comms :errors]) [:api-error args])
   (utils/mlog "No post-api for: " [message status]))
 
-(defmethod api-event [:entity-ids :success]
-  [target message status args state]
-  (update-in state [:entity-ids] (fnil into #{}) (get-in args [:resp :entity-ids])))
-
 (defmethod api-event [:created-docs :success]
   [target message status {:keys [docs]} state]
   (assoc-in state [:cust :created-docs] docs))

--- a/src-cljs/frontend/controllers/errors.cljs
+++ b/src-cljs/frontend/controllers/errors.cljs
@@ -83,10 +83,9 @@
 
 (defmethod post-error! :subscribe-to-document-error
   [container message {:keys [document-id]} previous-state current-state]
-  (when (:use-frontend-ids current-state)
-    (write-error-to-canvas (:db current-state)
-                           (:camera current-state)
-                           "There was an error connecting to the server.\nPlease refresh to try again."))
+  (write-error-to-canvas (:db current-state)
+                         (:camera current-state)
+                         "There was an error connecting to the server.\nPlease refresh to try again.")
   (js/Rollbar.error (str "subscribe to document failed for " document-id)))
 
 (defmethod post-error! :entity-ids-request-failed

--- a/src-cljs/frontend/db.cljs
+++ b/src-cljs/frontend/db.cljs
@@ -67,18 +67,12 @@
   "Provides an app-state-aware API for generating entity ids, returns a map
    with :entity-id and :state keys. Backwards compatible with dummy ids."
   [app-state]
-  (if (:use-frontend-ids app-state)
-    (let [{:keys [entity-id frontend-id-state]} (generate-entity-id @(:db app-state) (:frontend-id-state app-state))]
-      {:entity-id entity-id :state (assoc app-state :frontend-id-state frontend-id-state)})
-    (let [eid (first (:entity-ids app-state))]
-      {:entity-id eid :state (update-in app-state [:entity-ids] disj eid)})))
+  (let [{:keys [entity-id frontend-id-state]} (generate-entity-id @(:db app-state) (:frontend-id-state app-state))]
+    {:entity-id entity-id :state (assoc app-state :frontend-id-state frontend-id-state)}))
 
 (defn get-entity-ids
   "Provides an app-state-aware API for generating entity ids, returns a map
    with :entity-id and :state keys. Backwards compatible with dummy ids."
   [app-state n]
-  (if (:use-frontend-ids app-state)
-    (let [{:keys [entity-ids frontend-id-state]} (generate-entity-ids @(:db app-state) n (:frontend-id-state app-state))]
-      {:entity-ids entity-ids :state (assoc app-state :frontend-id-state frontend-id-state)})
-    (let [eids (take n (:entity-ids app-state))]
-      {:entity-ids eids :state (update-in app-state [:entity-ids] #(apply disj % eids))})))
+  (let [{:keys [entity-ids frontend-id-state]} (generate-entity-ids @(:db app-state) n (:frontend-id-state app-state))]
+    {:entity-ids entity-ids :state (assoc app-state :frontend-id-state frontend-id-state)}))

--- a/src/pc/server.clj
+++ b/src/pc/server.clj
@@ -56,12 +56,6 @@
   (swap! bucket-doc-ids (fn [b]
                           (set/intersection b (set (keys @sente/document-subs))))))
 
-;; We'll redefine this function at run-time to test in production
-(defn use-frontend-ids? [req]
-  (contains? #{"dwwoelfel@gmail.com" "danny.newidea@gmail.com"} (get-in req [:auth :cust :cust/email]))
-  false
-  )
-
 ;; TODO: make this reloadable without reloading the server
 (defn app [sente-state]
   (routes
@@ -129,8 +123,7 @@
           (if doc
             (content/app (merge {:CSRFToken ring.middleware.anti-forgery/*anti-forgery-token*
                                  :google-client-id (google-client-id)
-                                 :sente-id (-> req :session :sente-id)
-                                 :use-frontend-ids (use-frontend-ids? req)}
+                                 :sente-id (-> req :session :sente-id)}
                                 ;; TODO: Uncomment this once we have a way to send just the novelty to the client.
                                 ;;       Also need a way to handle transactions before sente connects
                                 ;; (when (auth/has-document-permission? db doc (-> req :auth) :admin)


### PR DESCRIPTION
I've already eval'd the code that tells clients to use frontend ids. This just removes the entity id fetcher and some code that was deprecated by the switch. There's a bit more dead code to remove, but will wait for a bit just in case.
