### PR TITLE
Switch to undertow (wrapped by immutant) for the web server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [clj-statsd "0.3.10"]
 
                  [cider/cider-nrepl "0.8.2"]
-                 [clj-http "1.0.1" :exclusions [commons-codec]]
+                 [clj-http "1.0.1" :exclusions [commons-codec clj-tuple potemkin]]
                  [com.datomic/datomic-pro "0.9.5130" :exclusions [org.slf4j/slf4j-nop
                                                                   org.slf4j/slf4j-api
                                                                   com.amazonaws/aws-java-sdk]]
@@ -38,10 +38,17 @@
                  ;; uses a url-safe token
                  [dwwoelfel/ring-anti-forgery "1.0.0-cbd219138abf4e9916a51caa7629c357b5d164af" :exclusions [hiccup]]
                  [http-kit "2.1.18-c9c0b155a4ab05630d332a7d2da0aaf433889772"]
-                 [com.taoensso/sente "1.4.0-alpha2" :exclusions [http-kit]]
+                 [com.taoensso/sente "1.4.1" :exclusions [http-kit]]
                  [clj-stacktrace "0.2.8"]
+                 [org.immutant/web "2.0.0-beta2" :exclusions [org.clojure/java.classpath
+                                                              org.jboss.logging/jboss-logging
+                                                              org.slf4j/slf4j-nop
+                                                              org.slf4j/slf4j-api
+                                                              org.slf4j/slf4j-simple
+                                                              org.slf4j/slf4j-log4j12
+                                                              ch.qos.logback/logback-classic]]
 
-                 [org.clojure/tools.reader "0.8.13"]
+                 [org.clojure/tools.reader "0.8.16"]
                  [com.google.guava/guava "18.0"]
 
                  [schejulure "1.0.1"]

--- a/src/pc/http/admin.clj
+++ b/src/pc/http/admin.clj
@@ -3,8 +3,8 @@
             [clj-time.format :as time-format]
             [compojure.core]
             [compojure.route]
+            [immutant.web :as web]
             [ns-tracker.core :refer (ns-tracker)]
-            [org.httpkit.server :as httpkit]
             [pc.datomic.admin-db :as admin-db]
             [pc.http.admin.auth :as auth]
             [pc.http.admin.inner :as inner]
@@ -54,12 +54,13 @@
     (logging-handler/wrap-logging)))
 
 (defn start []
-  (def server (httpkit/run-server (handler)
-                                  {:port (profile/admin-http-port)})))
+  (def server (web/server (web/run
+                            (handler)
+                            {:port (profile/admin-http-port)}))))
 
 (defn stop [& {:keys [timeout]
                :or {timeout 0}}]
-  (server :timeout timeout))
+  (.stop server))
 
 (defn restart []
   (stop)

--- a/src/pc/http/sente.clj
+++ b/src/pc/http/sente.clj
@@ -26,7 +26,7 @@
             [pc.utils :as utils]
             [slingshot.slingshot :refer (try+ throw+)]
             [taoensso.sente :as sente]
-            [taoensso.sente.server-adapters.http-kit :refer (http-kit-adapter)])
+            [taoensso.sente.server-adapters.immutant :refer (sente-web-server-adapter)])
   (:import java.util.UUID))
 
 ;; TODO: find a way to restart sente
@@ -734,7 +734,7 @@
 (defn init []
   (let [{:keys [ch-recv send-fn ajax-post-fn connected-uids
                 ajax-get-or-ws-handshake-fn] :as fns} (sente/make-channel-socket!
-                                                       http-kit-adapter
+                                                       sente-web-server-adapter
                                                        {:user-id-fn #'user-id-fn})]
     (reset! sente-state fns)
     (setup-ws-handlers fns)

--- a/src/pc/server.clj
+++ b/src/pc/server.clj
@@ -5,7 +5,7 @@
             [compojure.core]
             [compojure.route]
             [datomic.api :refer [db q] :as d]
-            [org.httpkit.server :as httpkit]
+            [immutant.web :as web]
             [pc.datomic :as pcd]
             [pc.http.datomic :as datomic]
             [pc.http.handlers.errors :as errors-handler]
@@ -98,12 +98,13 @@
     (logging-handler/wrap-logging)))
 
 (defn start [sente-state]
-  (def server (httpkit/run-server (handler sente-state)
-                                  {:port (profile/http-port)})))
+  (def server (web/server (web/run
+                            (handler sente-state)
+                            {:port (profile/http-port)}))))
 
 (defn stop [& {:keys [timeout]
                :or {timeout 0}}]
-  (server :timeout timeout))
+  (.stop server))
 
 (defn restart []
   (stop)


### PR DESCRIPTION
The motivation for this switch is that we're having some trouble with websocket messages stacking up for slow clients. It's not too bad right now, but we want to release features (e.g. read-only docs, webinars) that won't work very well with this problem.

We can solve most of the problem by dropping old mouse-move and in-progress drawing websocket messages from collaborators. You typically only need to see the latest state, so dropping intermediate messages isn't a problem.

http-kit only gives us a black hole to throw messages into. We don't know which of those messages were sent, so we don't have a way to discard intermediate messages. Immutant provides an :on-complete callback that we can use to accomplish our goal.

Other reasons for the switch:
- http-kit is being poorly maintained: they still haven't pushed the latest release anywhere public
- immutant is well-maintained and has a good track record
- undertow is multi-threaded, which means we can scale up rather than out
- in my (unscientific) testing, undertow had much better memory usage when messages started getting backed up
